### PR TITLE
Fix: global option being ignored in SchemaRegistryModule.registerAsync

### DIFF
--- a/src/schema-registry.module.ts
+++ b/src/schema-registry.module.ts
@@ -37,6 +37,7 @@ export class SchemaRegistryModule {
       imports: options.imports || [],
       providers,
       exports: providers,
+      global: options.global,
     };
   }
 


### PR DESCRIPTION
### Description
Passing the `global: true` option in the `registerAsync` method does not register the module globally.

### Steps to Reproduce the Bug
1. Create a module using `SchemaRegistryModule.registerAsync` with the global option set to true.
2. Use the `@InjectSchemaRegistry()` injection in a module where the schemaRegistryModule is not imported explicitly
3. Notice that the service injection fails, indicating that the module was not registered globally.

### Expected Behavior
When `global: true` is passed, the module should be available globally, allowing services provided by the module to be injected into other modules without needing to explicitly import the module.

### Additional Notes
This change should not introduce any breaking changes. The global option should now work as expected when used in `SchemaRegistryModule.registerAsync `.